### PR TITLE
Remove some caching

### DIFF
--- a/lib/cached_enumeration/version.rb
+++ b/lib/cached_enumeration/version.rb
@@ -1,3 +1,3 @@
 module CachedEnumeration
-  VERSION = "1.0.4"
+  VERSION = "1.1.0"
 end

--- a/spec/lib/association_spec.rb
+++ b/spec/lib/association_spec.rb
@@ -40,49 +40,4 @@ describe 'association caching' do
     Profile.delete_all
   end
 
-
-  let(:him) { Profile.create(:name => 'Him', :gender => Gender::MALE) }
-  let(:her) { Profile.create(:name => 'Her', :gender => Gender::FEMALE) }
-
-
-  context "should use cached when going over association" do
-
-    it 'should find the cached ones (no :include)' do
-      him
-      him.reload #to empty the assoc cache
-
-      Gender.connection.should_not_receive(:exec_query)
-      him.gender.name.should == 'male'
-    end
-
-=begin
-
-does not work: Profile.includes(:gender).all creates two sql statements
-to load profiles AND genders associated to them. The 2nd one (for genders)
-does not run through standard finders but is done in the depth of AR.
-So caching does not work here.
-
-Possible improvements:
-* intercept `all' for ALL AR models and take out inclusions where the
-  model is cached (restricted to simple cases of belongs_to)
-* find an entry point deeper in AR where associations are loaded and
-  modify that to consider model caching
-
-Until then, one should just leave out cached models in inclusions,
-though that makes switching caching on or off for a model quite difficult.
-
-    it "should take the :include from the cache" do
-      #logged do
-      him;her
-        ActiveRecord::Base.connection.should_receive(:exec_query).once.and_call_original
-        all=Profile.includes(:gender).all
-        ActiveRecord::Base.connection.should_not_receive(:exec_query)
-        him.gender.name.should == 'male'
-        her.gender.name.should == 'female'
-      #end
-    end
-=end
-
-
-  end
 end

--- a/spec/lib/cached_enumeration_spec.rb
+++ b/spec/lib/cached_enumeration_spec.rb
@@ -72,7 +72,7 @@ describe 'simple caching' do
       @klass.connection.should_receive(:exec_query).and_call_original
       @klass.find(:all, :conditions => "name = 'one'").size.should == 1
     end
-      
+
     it 'should fire db queries if all with select parameter is used through find(:all)' do
       @klass.cache_enumeration.cache!
       @klass.connection.should_receive(:exec_query).and_call_original
@@ -81,49 +81,7 @@ describe 'simple caching' do
         entry.other
       }.should raise_error(ActiveModel::MissingAttributeError, 'missing attribute: other')
     end
-      
-  end
 
-  context 'first' do
-    it 'should find the first entry' do
-      @klass.cache_enumeration.cache!
-      @klass.first.should == one
-    end
-    it 'should consider options' do
-      @klass.cache_enumeration.cache!
-      @klass.connection.should_receive(:exec_query).and_call_original
-      @klass.first(:order=>'id desc').should == three
-    end
-    it 'should allow hash conditions (and use cache)' do
-      @klass.cache_enumeration.cache!
-      @klass.connection.should_not_receive(:exec_query)
-      @klass.where(:name => 'three').first.should == three
-    end
-    it 'should allow hash conditions (and ask db if unhashed)' do
-      @klass.cache_enumeration.cache!
-      @klass.connection.should_receive(:exec_query).and_call_original
-      @klass.where(:other => 'drei').first.should == three
-    end
-    it 'should allow hash conditions in first (and use cache)' do
-      @klass.cache_enumeration.cache!
-      @klass.connection.should_not_receive(:exec_query)
-      @klass.first(:conditions => { :name => 'three' }).should == three
-    end
-    it 'should allow hash conditions in first (and ask db if unhashed)' do
-      @klass.cache_enumeration.cache!
-      @klass.connection.should_receive(:exec_query).and_call_original
-      @klass.first(:conditions => { :other => 'drei' }).should == three
-    end
-    it 'should allow string conditions in first' do
-      @klass.cache_enumeration.cache!
-      @klass.connection.should_receive(:exec_query).and_call_original
-      @klass.first(:conditions=>"name = 'three'").should == three
-    end
-    it 'should allow string conditions in where' do
-      @klass.cache_enumeration.cache!
-      @klass.connection.should_receive(:exec_query).and_call_original
-      @klass.where("name = 'three'").first.should == three
-    end
   end
 
   context "finders" do
@@ -131,30 +89,12 @@ describe 'simple caching' do
       @klass.cache_enumeration(:constantize => false)
     end
 
-    it 'should find objects providing id' do
-      one; three
-      three=@klass.find_by_name("three")
-      @klass.cache_enumeration.cache!
-      @klass.connection.should_not_receive(:exec_query)
-
-      @klass.find(one.id).id.should == one.id
-      @klass.find(one.id).frozen?().should be_true
-      @klass.find([one.id])[0].id.should == one.id
-      @klass.find([]).size.should == 0
-      @klass.find([one.id, three.id]).collect { |item| item.id }.should == [one.id, three.id]
-      lambda { @klass.find(0) }.should raise_error(ActiveRecord::RecordNotFound)
-      lambda { @klass.find(nil) }.should raise_error(ActiveRecord::RecordNotFound)
-    end
-
     it 'should find objects by_id' do
       one
       @klass.cache_enumeration.cache!
       @klass.connection.should_not_receive(:exec_query)
 
-      @klass.find_by_id(one.id).id.should == one.id
       @klass.by_id(one.id).id.should == one.id
-      @klass.find_by_id(one.id.to_s).id.should == one.id
-      @klass.find_by_id(0).should be_nil
     end
 
     it 'should find objects by_name' do
@@ -162,9 +102,7 @@ describe 'simple caching' do
       @klass.cache_enumeration.cache!
       @klass.connection.should_not_receive(:exec_query)
 
-      @klass.find_by_name('one').id.should == one.id
       @klass.by_name('one').id.should == one.id
-      @klass.find_by_name('no such name').should be_nil
     end
 
   end
@@ -175,9 +113,7 @@ describe 'simple caching' do
       @klass.cache_enumeration(:hashed => ['id', 'other', 'name']).cache!
       @klass.connection.should_not_receive(:exec_query)
 
-      @klass.find_by_other('eins').id.should ==one.id
       @klass.by_other('eins').id.should == one.id
-      @klass.find_by_name('one').id.should ==one.id
       @klass.by_name('one').id.should == one.id
     end
   end


### PR DESCRIPTION
Rails 4.2 will have "AdequateRecord", which prevents us from
caching certain calls (unless we wanted to override find itself).

Therefore, we are trying the impact of this ahead of time in Rails 3.2 to see
what performance is like if we do not cache a few things. What we're trying
to see is the worst-case scenario. Request time will likely drop in Rails 4.2
again since "AdequateRecord" is faster than ActiveRecord in Rails 3.2 for many
scenarios which were cached previously.

Before this change, we have the following scenario:
- +all+ is cached (with the alias +cached_all+)
- +where+ is not cached
- +by_xyz+ is cached (depending on all_with_....)
- +find_by_xyz+ is cached (depending on all_with_...)
- +find+ is cached (depending on find_one_with_.../find_some_with...)
- +first+ is cached (depending on find_first_with_....)
- Constants are cached (depending on all_with_...)

After this change, we only cache constants, +all+ and +by_xyz+.

In Rails 4.2, we're going to implement +by_xyz+ by caching +where+.
We are dropping +find_by_xyz+ too since that is using "AdequateRecord" in
Rails 4.2 by default.
