### PR TITLE
Remove some caching

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,7 @@
 language: ruby
 script: "bundle exec rake spec"
 rvm:
-  - 1.8.7
-  - 1.9.3
   - 2.0.0
-notifications:
-  recipients:
-    - peter.schrammel@experteer.com
-branches:
-  only:
-    - master
-    - rails32
+  - rbx-2.2.10
+  - 2.1.3
 

--- a/lib/cached_enumeration/cached_enumeration.rb
+++ b/lib/cached_enumeration/cached_enumeration.rb
@@ -1,52 +1,47 @@
 module CachedEnumeration
 =begin rdoc
-provide cached access to enumeration values
-       
-usage: add cache_enumeration <params> to ActiveRecord class
+Provide cached access to enumeration values
 
-parameters are
+Usage: In your ActiveRecord class, add
+
+  cache_enumeration <params>
+
+Parameters are
   :order  order of items in cached_all (default: 'id')
   :hashed list of attributes to provide hashes for (default: [ 'id', 'name' ];
           id will always be added to that list, if missing
   :constantize  attribute to provide constants for (default: 'name')
               use nil, not to generate constants
 
-cached methods are:
-find_from_ids( <id> ) or find_from_ids( [ <id>, <id>, ... ] )
-   providing cached  find( <id> ) or find( [ <id>, <id>, ... ] )
-find_by_XY / by_XY for all hashed attributes (by_XY is deprecated)
-cached_all 
+Cached methods are:
+  by_XY for all hashed attributes
+  cached_all
 
-besides constants using the upcase name are set up providing the entries
+Besides, constants using the upcase name are set up providing the entries
 
-note that all objects (arrays, maps and the models themselfs) are frozen
+Note that all objects (arrays, maps and the models themselfs) are frozen
 to avoid unintentional changes.
 
 Cachability of enumerations does not imply that all enumeration access should
 be cached. This is a question that needs to be well thought depending on the
 size of the enumeration and the number of accesses to the cached data.
-
-The by_XY finder should be avoided as the find_by_XY will be available with
-and without cache.
 =end
   class Cache
     attr_reader :options
 
     def initialize(base, params)
-      @options=init_options(params)
-      @cache={} #cache by keys
-      @all=[] #cache of all
-      @status=:uncached #can be :uncached,:cashing,:cached
-      @klass=base
+      @options = init_options(params)
+      @cache = {} # cache by keys
+      @all = [] # cache of all
+      @status = :uncached # can be :uncached,:caching,:cached
+      @klass = base
 
-      #base.extend(ClassMethods)
-      #base.reset_column_information
       base_singleton = class << base;
         self
       end
 
       patch_const_missing(base_singleton) if @options[:constantize]
-      create_find_by_methods(base_singleton)
+      create_by_methods(base_singleton)
     end
 
     def all
@@ -54,16 +49,16 @@ and without cache.
       @all
     end
 
-    #returns a value from a cache
-    #@param String att name of the attribute
-    #@param String key value of the attribute
+    # Returns a value from a cache
+    # @param String att name of the attribute
+    # @param String key value of the attribute
     def get_by(att, key)
       ensure_caches
       @cache[att][key]
     end
 
-    #forces a cache
-    #@return Boolean true is it just cached, false if it was already cached
+    # Forces a cache
+    # @return Boolean true is it just cached, false if it was already cached
     def cache!
       ensure_caches
     end
@@ -72,10 +67,10 @@ and without cache.
 
     def ensure_caches
       return false if cached? || caching?
-      @status=:caching
+      @status = :caching
 
       hashes = Hash.new do |hash, key|
-        hash[key]=Hash.new
+        hash[key] = Hash.new
       end
 
       @all = @klass.order(@options[:order]).all.freeze
@@ -88,18 +83,18 @@ and without cache.
 
       create_constants if @options[:constantize]
 
-      @cache=hashes
-      @status=:cached
+      @cache = hashes
+      @status = :cached
       true
     end
 
 
     def cached?
-      @status==:cached
+      @status == :cached
     end
 
     def caching?
-      @status==:caching
+      @status == :caching
     end
 
     def init_options(params)
@@ -108,8 +103,9 @@ and without cache.
         :hashed => ['id', 'name'],
         :constantize => 'name',
       }
-      #params check logic
-      params_diff=params.keys - defaults.keys
+
+      # params check logic
+      params_diff = params.keys - defaults.keys
       raise ArgumentError.new("unexpected parameters #{params_diff.inspect}, only #{defaults.keys.inspect} are understood") unless params_diff.empty?
 
       params = defaults.merge(params)
@@ -121,41 +117,37 @@ and without cache.
     end
 
     def create_constants
-      #puts "creating constants #{self.name}"
-      proc=@options[:constantize].respond_to?(:call)
+      proc = @options[:constantize].respond_to?(:call)
 
       @all.each do |model|
         if proc
-          const_name=@options[:constantize].call(model).upcase
+          const_name = @options[:constantize].call(model).upcase
         else
-          const_name=model.send(@options[:constantize]).upcase
+          const_name = model.send(@options[:constantize]).upcase
         end
 
-        #puts "caching: #{self.name}::#{const_name}"
         @klass.const_set const_name, model
       end
     end
 
-    def create_find_by_methods(base_singleton)
+    def create_by_methods(base_singleton)
       @options[:hashed].each do |att|
         if att == 'id'
-          base_singleton.__send__(:define_method, "find_by_#{att}") do |key|
-            #rewrite to use column type
+          base_singleton.__send__(:define_method, "by_#{att}") do |key|
             cache_enumeration.get_by(att, key.to_i)
           end
         else
-          base_singleton.__send__(:define_method, "find_by_#{att}") do |key|
+          base_singleton.__send__(:define_method, "by_#{att}") do |key|
             cache_enumeration.get_by(att, key)
           end
         end
-        base_singleton.__send__(:alias_method, "by_#{att}", "find_by_#{att}")
       end
 
     end
 
     def patch_const_missing(base_singleton)
-      # no class caching in derived classes
-      # introduced to avoid issues with Sales::ProductDomain 
+      # No class caching in derived classes
+      # Introduced to avoid issues with Sales::ProductDomain
       # and it's descendents
       return if @klass.parent.respond_to? :const_missing_with_cache_enumeration
       @klass.extend ConstMissing
@@ -164,65 +156,21 @@ and without cache.
 
     module ConstMissing
       def const_missing_with_cache_enumeration(const_name)
-        if cache_enumeration.cache! #if we just cached
-          self.const_get(const_name) #try again
+        if cache_enumeration.cache! # if we just cached
+          self.const_get(const_name) # try again
         else
-          const_missing_without_cache_enumeration(const_name) #fails as usual
+          const_missing_without_cache_enumeration(const_name) # fails as usual
         end
       end
     end
   end
 end
 
-#I override find_one, find_some and all so they do a cache lookup first
 class ActiveRecord::Relation
 
-  def find_first_with_cache_enumeration
-    equal_op = nil
-    if cache_enumeration_unmodified_but_where? && cache_enumeration?
-      case
-        when where_values.blank?
-          cache_enumeration.all.first
-        when where_values.size == 1 && 
-          where_values[0].kind_of?(Arel::Nodes::Node) &&
-          where_values[0].operator == :== &&
-          cache_enumeration.options[:hashed].include?(where_values[0].left.name)
-
-          cache_enumeration.get_by(where_values[0].left.name, where_values[0].right)
-        else
-          find_first_without_cache_enumeration
-      end
-    else
-      find_first_without_cache_enumeration
-    end
-  end
-
-  alias_method_chain :find_first, :cache_enumeration
-
-  def find_one_with_cache_enumeration(id)
-    if cache_enumeration_unmodified_query? && cache_enumeration?
-      cache_enumeration.get_by('id', id.to_i) ||
-        raise(ActiveRecord::RecordNotFound, "Couldn't find #{name} with ID=#{id}")
-    else
-      find_one_without_cache_enumeration(id)
-    end
-  end
-
-  alias_method_chain :find_one, :cache_enumeration
-
-  def find_some_with_cache_enumeration(ids)
-    if cache_enumeration_unmodified_query? && cache_enumeration?
-      ids.inject([]) do |res, id|
-        res << (cache_enumeration.get_by('id', id.to_i) ||
-          raise(ActiveRecord::RecordNotFound, "Couldn't find #{name} with ID=#{id}"))
-      end
-    else
-      find_some_without_cache_enumeration(ids)
-    end
-  end
-
-  alias_method_chain :find_some, :cache_enumeration
-
+  # There should be a Rails 4 version of this gem
+  # which can remove the need for cache_enumeration_unmodified_query?
+  # because +all+ does not take arguments anymore.
   def all_with_cache_enumeration(*args)
     if cache_enumeration_unmodified_query? && args.empty? && cache_enumeration?
       cache_enumeration.all
@@ -264,11 +212,9 @@ module ActiveRecord
         !@cache_enumeration.nil?
       end
 
-      #deprecated as 'all' should work now
       def cached_all
         cache_enumeration.all
       end
-
 
     end
   end

--- a/lib/cached_enumeration/version.rb
+++ b/lib/cached_enumeration/version.rb
@@ -1,3 +1,3 @@
 module CachedEnumeration
-  VERSION = "1.0.4"
+  VERSION = "1.1.0"
 end

--- a/spec/lib/association_spec.rb
+++ b/spec/lib/association_spec.rb
@@ -40,49 +40,4 @@ describe 'association caching' do
     Profile.delete_all
   end
 
-
-  let(:him) { Profile.create(:name => 'Him', :gender => Gender::MALE) }
-  let(:her) { Profile.create(:name => 'Her', :gender => Gender::FEMALE) }
-
-
-  context "should use cached when going over association" do
-
-    it 'should find the cached ones (no :include)' do
-      him
-      him.reload #to empty the assoc cache
-
-      Gender.connection.should_not_receive(:exec_query)
-      him.gender.name.should == 'male'
-    end
-
-=begin
-
-does not work: Profile.includes(:gender).all creates two sql statements
-to load profiles AND genders associated to them. The 2nd one (for genders)
-does not run through standard finders but is done in the depth of AR.
-So caching does not work here.
-
-Possible improvements:
-* intercept `all' for ALL AR models and take out inclusions where the
-  model is cached (restricted to simple cases of belongs_to)
-* find an entry point deeper in AR where associations are loaded and
-  modify that to consider model caching
-
-Until then, one should just leave out cached models in inclusions,
-though that makes switching caching on or off for a model quite difficult.
-
-    it "should take the :include from the cache" do
-      #logged do
-      him;her
-        ActiveRecord::Base.connection.should_receive(:exec_query).once.and_call_original
-        all=Profile.includes(:gender).all
-        ActiveRecord::Base.connection.should_not_receive(:exec_query)
-        him.gender.name.should == 'male'
-        her.gender.name.should == 'female'
-      #end
-    end
-=end
-
-
-  end
 end

--- a/spec/lib/cached_enumeration_spec.rb
+++ b/spec/lib/cached_enumeration_spec.rb
@@ -72,7 +72,7 @@ describe 'simple caching' do
       @klass.connection.should_receive(:exec_query).and_call_original
       @klass.find(:all, :conditions => "name = 'one'").size.should == 1
     end
-      
+
     it 'should fire db queries if all with select parameter is used through find(:all)' do
       @klass.cache_enumeration.cache!
       @klass.connection.should_receive(:exec_query).and_call_original
@@ -81,49 +81,7 @@ describe 'simple caching' do
         entry.other
       }.should raise_error(ActiveModel::MissingAttributeError, 'missing attribute: other')
     end
-      
-  end
 
-  context 'first' do
-    it 'should find the first entry' do
-      @klass.cache_enumeration.cache!
-      @klass.first.should == one
-    end
-    it 'should consider options' do
-      @klass.cache_enumeration.cache!
-      @klass.connection.should_receive(:exec_query).and_call_original
-      @klass.first(:order=>'id desc').should == three
-    end
-    it 'should allow hash conditions (and use cache)' do
-      @klass.cache_enumeration.cache!
-      @klass.connection.should_not_receive(:exec_query)
-      @klass.where(:name => 'three').first.should == three
-    end
-    it 'should allow hash conditions (and ask db if unhashed)' do
-      @klass.cache_enumeration.cache!
-      @klass.connection.should_receive(:exec_query).and_call_original
-      @klass.where(:other => 'drei').first.should == three
-    end
-    it 'should allow hash conditions in first (and use cache)' do
-      @klass.cache_enumeration.cache!
-      @klass.connection.should_not_receive(:exec_query)
-      @klass.first(:conditions => { :name => 'three' }).should == three
-    end
-    it 'should allow hash conditions in first (and ask db if unhashed)' do
-      @klass.cache_enumeration.cache!
-      @klass.connection.should_receive(:exec_query).and_call_original
-      @klass.first(:conditions => { :other => 'drei' }).should == three
-    end
-    it 'should allow string conditions in first' do
-      @klass.cache_enumeration.cache!
-      @klass.connection.should_receive(:exec_query).and_call_original
-      @klass.first(:conditions=>"name = 'three'").should == three
-    end
-    it 'should allow string conditions in where' do
-      @klass.cache_enumeration.cache!
-      @klass.connection.should_receive(:exec_query).and_call_original
-      @klass.where("name = 'three'").first.should == three
-    end
   end
 
   context "finders" do
@@ -131,30 +89,12 @@ describe 'simple caching' do
       @klass.cache_enumeration(:constantize => false)
     end
 
-    it 'should find objects providing id' do
-      one; three
-      three=@klass.find_by_name("three")
-      @klass.cache_enumeration.cache!
-      @klass.connection.should_not_receive(:exec_query)
-
-      @klass.find(one.id).id.should == one.id
-      @klass.find(one.id).frozen?().should be_true
-      @klass.find([one.id])[0].id.should == one.id
-      @klass.find([]).size.should == 0
-      @klass.find([one.id, three.id]).collect { |item| item.id }.should == [one.id, three.id]
-      lambda { @klass.find(0) }.should raise_error(ActiveRecord::RecordNotFound)
-      lambda { @klass.find(nil) }.should raise_error(ActiveRecord::RecordNotFound)
-    end
-
     it 'should find objects by_id' do
       one
       @klass.cache_enumeration.cache!
       @klass.connection.should_not_receive(:exec_query)
 
-      @klass.find_by_id(one.id).id.should == one.id
       @klass.by_id(one.id).id.should == one.id
-      @klass.find_by_id(one.id.to_s).id.should == one.id
-      @klass.find_by_id(0).should be_nil
     end
 
     it 'should find objects by_name' do
@@ -162,9 +102,7 @@ describe 'simple caching' do
       @klass.cache_enumeration.cache!
       @klass.connection.should_not_receive(:exec_query)
 
-      @klass.find_by_name('one').id.should == one.id
       @klass.by_name('one').id.should == one.id
-      @klass.find_by_name('no such name').should be_nil
     end
 
   end
@@ -175,9 +113,7 @@ describe 'simple caching' do
       @klass.cache_enumeration(:hashed => ['id', 'other', 'name']).cache!
       @klass.connection.should_not_receive(:exec_query)
 
-      @klass.find_by_other('eins').id.should ==one.id
       @klass.by_other('eins').id.should == one.id
-      @klass.find_by_name('one').id.should ==one.id
       @klass.by_name('one').id.should == one.id
     end
   end


### PR DESCRIPTION
Rails 4.2 will have "AdequateRecord", which prevents us from
caching certain calls (unless we wanted to override find itself).

Therefore, we are trying the impact of this ahead of time in Rails 3.2 to see
what performance is like if we do not cache a few things. What we're trying
to see is the worst-case scenario. Request time will likely drop in Rails 4.2
again since "AdequateRecord" is faster than ActiveRecord in Rails 3.2 for many
scenarios which were cached previously.

Before this change, we have the following scenario:
- +all+ is cached (with the alias +cached_all+)
- +where+ is not cached
- +by_xyz+ is cached (depending on all_with_....)
- +find_by_xyz+ is cached (depending on all_with_...)
- +find+ is cached (depending on find_one_with_.../find_some_with...)
- +first+ is cached (depending on find_first_with_....)
- Constants are cached (depending on all_with_...)

After this change, we only cache constants, +all+ and +by_xyz+.
