### PR TITLE
Fix ordering of all

### DIFF
--- a/lib/cached_enumeration/cached_enumeration.rb
+++ b/lib/cached_enumeration/cached_enumeration.rb
@@ -143,10 +143,6 @@ size of the enumeration and the number of accesses to the cached data.
       base_singleton.__send__(:define_method, :cached_all) do
         cache_enumeration.all
       end
-      base_singleton.__send__(:define_method, :all_with_cache_enumeration) do
-        cache_enumeration.cached? && current_scope.nil? ? cached_all : all_without_cache_enumeration
-      end
-      base_singleton.__send__(:alias_method_chain, :all, :cache_enumeration)
     end
 
     def alias_first_method(base_singleton)


### PR DESCRIPTION
+all+ is called internally in places we do not expect, and where the
+current_scope+ is +nil+. That meant that the default order (by +id+ in most
cases) would be applied even for queries like
+Language.where(system_language: true).order(:label)+

The change here throws away caching of +all+. That should not be too bad:
- It cannot be used anyway if there are any scopes
- It is only a Relation, so we could still see a database call. It has to be
  said that Rails seems to be smart and doesn't execute a query again when the
  relation is used twice, however that effect should be seen in the uncached
  version then, too.
