### PR TITLE
Use module_parent instead of parent

### DIFF
--- a/lib/cached_enumeration/cached_enumeration.rb
+++ b/lib/cached_enumeration/cached_enumeration.rb
@@ -216,7 +216,7 @@ module ActiveRecord
       def cache_enumeration(params = {})
         if params[:reset]
           @cache_enumeration = nil
-        elsif self.parent.respond_to? :const_missing_with_cache_enumeration
+        elsif self.module_parent.respond_to? :const_missing_with_cache_enumeration
           @cache_enumeration ||= CachedEnumeration::NoCache.new
         else
           @cache_enumeration ||= CachedEnumeration::Cache.new(self, params)

--- a/lib/cached_enumeration/version.rb
+++ b/lib/cached_enumeration/version.rb
@@ -1,3 +1,3 @@
 module CachedEnumeration
-  VERSION = "3.2.1"
+  VERSION = "3.3.0"
 end


### PR DESCRIPTION
Module::parent is incompatible with rails 6.1

https://apidock.com/rails/v6.0.0/Module/parent
https://apidock.com/rails/v6.1.3.1/Module/module_parent

@tnitsche